### PR TITLE
Add ability to assign enum values as strings

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -210,9 +210,10 @@ foreign-keys:
     # Of course, you can mix them with regular queries:
     Part.objects.filter(name='Cog', eav__height=7.8)
 
-    # Querying enums looks as follows:
+    # Querying enums works either by enum instance or by it's text representation as follows:
     yes = EnumValue.objects.get(name='Yes')
-    Part.objects.filter(eav__is_available=yes)
+    Part.objects.filter(eav__is_available=yes)  # via EnumValue
+    Part.objects.filter(eav__is_available='yes)  # via EnumValue's value
 
 You can use ``Q`` expressions too:
 

--- a/eav/models.py
+++ b/eav/models.py
@@ -19,9 +19,17 @@ from django.db.models.base import ModelBase
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
+from .validators import (
+    validate_text,
+    validate_float,
+    validate_int,
+    validate_date,
+    validate_bool,
+    validate_object,
+    validate_enum
+)
 from .exceptions import IllegalAssignmentException
 from .fields import EavDatatypeField, EavSlugField
-from .validators import *
 from . import register
 
 
@@ -245,7 +253,9 @@ class Attribute(models.Model):
             validator(value)
 
         if self.datatype == self.TYPE_ENUM:
-            if value not in self.enum_group.values.all():
+            if isinstance(value, EnumValue):
+                value = value.value
+            if not self.enum_group.values.filter(value=value).exists():
                 raise ValidationError(
                     _('%(val)s is not a valid choice for %(attr)s')
                     % dict(val = value, attr = self)
@@ -530,6 +540,8 @@ class Entity(object):
         for attribute in self.get_all_attributes():
             if self._hasattr(attribute.slug):
                 attribute_value = self._getattr(attribute.slug)
+                if attribute.datatype == Attribute.TYPE_ENUM and not isinstance(attribute_value, EnumValue):
+                    attribute_value = EnumValue.objects.get(value=attribute_value)
                 attribute.save_value(self.instance, attribute_value)
 
     def validate_attributes(self):

--- a/eav/models.py
+++ b/eav/models.py
@@ -415,18 +415,6 @@ class Value(models.Model):
         self.full_clean()
         super(Value, self).save(*args, **kwargs)
 
-    def clean(self):
-        """
-        Raises ``ValidationError`` if this value's attribute is *TYPE_ENUM*
-        and value_enum is not a valid choice for this value's attribute.
-        """
-        if self.attribute.datatype == Attribute.TYPE_ENUM and self.value_enum:
-            if self.value_enum not in self.attribute.enum_group.values.all():
-                raise ValidationError(
-                    _('%(enum)s is not a valid choice for %(attr)s')
-                    % dict(enum = self.value_enum, attr = self.attribute)
-                )
-
     def _get_value(self):
         """
         Return the python object this value is holding

--- a/eav/queryset.py
+++ b/eav/queryset.py
@@ -28,7 +28,7 @@ from django.db.models import Case, IntegerField, Q, When
 from django.db.models.query import QuerySet
 from django.db.utils import NotSupportedError
 
-from .models import Attribute, Value
+from .models import Attribute, Value, EnumValue
 
 
 def is_eav_and_leaf(expr, gr_name):
@@ -234,7 +234,10 @@ def expand_eav_filter(model_cls, key, value):
         gr_name = config_cls.generic_relation_attr
         datatype = Attribute.objects.get(slug=slug).datatype
 
-        lookup = '__%s' % fields[2] if len(fields) > 2 else ''
+        if datatype == Attribute.TYPE_ENUM and not isinstance(value, EnumValue):
+            lookup = '__value__{}'.format(fields[2]) if len(fields) > 2 else '__value'
+        else:
+            lookup = '__{}'.format(fields[2]) if len(fields) > 2 else ''
         kwargs = {
             'value_{}{}'.format(datatype, lookup): value,
             'attribute__slug': slug

--- a/eav/validators.py
+++ b/eav/validators.py
@@ -81,8 +81,5 @@ def validate_enum(value):
     """
     from .models import EnumValue
 
-    if not isinstance(value, EnumValue):
-        raise ValidationError(_(u"Must be an EnumValue model object instance"))
-
-    if not value.pk:
+    if isinstance(value, EnumValue) and not value.pk:
         raise ValidationError(_(u"EnumValue has not been saved yet"))

--- a/tests/data_validation.py
+++ b/tests/data_validation.py
@@ -155,8 +155,6 @@ class DataValidation(TestCase):
         self.assertRaises(ValidationError, p.save)
         p.eav.fever = object
         self.assertRaises(ValidationError, p.save)
-        p.eav.fever = 'yes'
-        self.assertRaises(ValidationError, p.save)
         p.eav.fever = green
         self.assertRaises(ValidationError, p.save)
         p.eav.fever = EnumValue(value='yes')

--- a/tests/misc_models.py
+++ b/tests/misc_models.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from eav.models import EnumGroup, Attribute, Value
+from eav.models import EnumGroup, Attribute, Value, EnumValue
 
 import eav
 from .models import Patient
@@ -25,3 +25,17 @@ class MiscModels(TestCase):
         p.eav.age = None
         p.save()
         self.assertEqual(Value.objects.count(), 0)
+
+    def test_string_enum_value_assignment(self):
+        yes = EnumValue.objects.create(value='yes')
+        no = EnumValue.objects.create(value='no')
+        ynu = EnumGroup.objects.create(name='Yes / No / Unknown')
+        ynu.values.add(yes)
+        ynu.values.add(no)
+        Attribute.objects.create(name='is_patient', datatype=Attribute.TYPE_ENUM, enum_group=ynu)
+        eav.register(Patient)
+        p = Patient.objects.create(name='Joe')
+        p.eav.is_patient = 'yes'
+        p.save()
+        p = Patient.objects.get(name='Joe')  # get from DB again
+        self.assertEqual(p.eav.is_patient, yes)

--- a/tests/queries.py
+++ b/tests/queries.py
@@ -95,6 +95,12 @@ class Queries(TestCase):
         self.assertEqual(p.count(), 2)
 
         # Anne
+        q1 = Q(eav__city__contains='Y') & Q(eav__fever='no')
+        q2 = Q(eav__age=3)
+        p = Patient.objects.filter(q1 & q2)
+        self.assertEqual(p.count(), 1)
+
+        # Anne
         q1 = Q(eav__city__contains='Y') & Q(eav__fever=self.no)
         q2 = Q(eav__age=3)
         p = Patient.objects.filter(q1 & q2)


### PR DESCRIPTION
## Description
Currently you have to assign `EnumValue` instance in order to save enum data. With this change it's possible to assign just a string, like this: `p.eav.enum_attribute = 'yes'`

## Motivation and Context
Makes API more convenient.

## How Has This Been Tested?
Created unit test.

## Types of Changes
* What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
