### PR TITLE
fix generic entity filter problem

### DIFF
--- a/eav/queryset.py
+++ b/eav/queryset.py
@@ -234,12 +234,17 @@ def expand_eav_filter(model_cls, key, value):
         gr_name = config_cls.generic_relation_attr
         datatype = Attribute.objects.get(slug=slug).datatype
 
+        value_key = ''
         if datatype == Attribute.TYPE_ENUM and not isinstance(value, EnumValue):
             lookup = '__value__{}'.format(fields[2]) if len(fields) > 2 else '__value'
+            value_key = 'value_{}{}'.format(datatype, lookup)
+        elif datatype == Attribute.TYPE_OBJECT:
+            value_key = 'generic_value_id'
         else:
             lookup = '__{}'.format(fields[2]) if len(fields) > 2 else ''
+            value_key = 'value_{}{}'.format(datatype, lookup)
         kwargs = {
-            'value_{}{}'.format(datatype, lookup): value,
+            value_key: value,
             'attribute__slug': slug
         }
         value = Value.objects.filter(**kwargs)


### PR DESCRIPTION

## Description
When executing queries, most of the a value field with a prefix of "value_" is used. However in the case of attributes of type object, there is only a "virtual" value_object field which do not exists on the DB side. "value_object" field is covered by "generic_value_id" field in the database. Therefore I have changed the value lookup for the object attributes. They now use the key "generic_value_id" instead of "value_object". The rest are left as is.

## Motivation and Context
* It fixes the ability to query attributes of type objects
* #48 

## How Has This Been Tested?
* I tested this with my own project/deployment on Django 2.2.10 and python 3.7

## Types of Changes
* What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
