### PR TITLE
Made changes necessary to bump supported Django version to 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
         - python: 3.7-dev
           env: TOXENV=py37-django20
         - python: 3.7-dev
+          env: TOXENV=py37-django30
+        - python: 3.7-dev
           env: TOXENV=py37-djangotip
 install:
     - pip install Django>=1.11

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/159540d899bd41bb860f0ce996427e1f)](https://www.codacy.com/app/IwoHerka/django-eav2?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=makimo/django-eav2&amp;utm_campaign=Badge_Grade)
 [![Maintainability](https://api.codeclimate.com/v1/badges/b90eacf7a90db4b58f13/maintainability)](https://codeclimate.com/github/makimo/django-eav2/maintainability)
 ![Python Version](https://img.shields.io/badge/Python-2.7,%203.5,%203.6,%203.7dev-blue.svg)
-![Django Version](https://img.shields.io/badge/Django-1.11,%202.0,%20tip-green.svg)
+![Django Version](https://img.shields.io/badge/Django-1.11,%202.0,%203.0,%20tip-green.svg)
 
 ## Django EAV 2 - Entity-Attribute-Value storage for Django
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,10 +10,35 @@ INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.sites',
     'django.contrib.admin',
+    'django.contrib.messages',  # Required for admin app.
     'django.contrib.contenttypes',
-    "tests",
-    "eav"
+    'tests',
+    'eav'
 ]
+
+MIDDLEWARE = [
+    # Following 3 middleware required for admin app.
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware'
+]
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
 
 DATABASES = {
     'default': {

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     py27-django{111},
-    py35-django{111,20,tip},
-    py36-django{111,20,tip},
-    py37-django{111,20,tip},
+    py35-django{111,20,30,tip},
+    py36-django{111,20,30,tip},
+    py37-django{111,20,30,tip},
     migrationscheck
 
 [testenv]
@@ -12,6 +12,7 @@ pip_pre=True
 deps =
     django111: Django >=1.11, <2.0
     django20: Django >= 2.0, <2.1
+    django30: Django >= 3.0, <3.1
     djangotip: Django
     
 commands = 


### PR DESCRIPTION
The current version of django-eav2 fails the provided travis-ci tests because it attempts to test against the newest version of django (django-tip). Django-tip at this point in time refers to Django version 3.0 which requires minor changes to [`tests/test_settings.py`](https://github.com/makimo/django-eav2/blob/89358a6c463453803eb666d73893051bab9af06b/tests/test_settings.py). Since the project passes its own tests when using Django 3.0 I figured that the version just needed to be bumped so I added an environment for Django 3.0 in Tox and Travis.

## Description
### Current Behavior
This project currently fails travis-ci tests. This also causes [pull request 49](https://github.com/makimo/django-eav2/pull/49) which would otherwise pass the travis-ci tests to fail them. (I merged PR 49 into my fork and it passed the tests with the bumped Django version.)

### Changes
* Added a Tox environment for Django 3.0 on Python 3.7.
* Added the Tox environment to the Travis configuration file to be automatically tested.
* Adds appropriate middleware and template engine to [`tests/test_settings.py`](https://github.com/makimo/django-eav2/blob/89358a6c463453803eb666d73893051bab9af06b/tests/test_settings.py) to make the admin app work.
* Updated README to reflect support for Django 3.0.

## Motivation and Context
* Makes compatibility with Django 3.0 official
* Makes Master Branch pass tests.
* Makes PR 49 work.

## How Has This Been Tested?
N/A

## Types of Changes
* What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please go easy on me! This is my first PR.
Thank you!
