### PR TITLE
Allow enum value to be None on save

### DIFF
--- a/eav/models.py
+++ b/eav/models.py
@@ -529,7 +529,8 @@ class Entity(object):
             if self._hasattr(attribute.slug):
                 attribute_value = self._getattr(attribute.slug)
                 if attribute.datatype == Attribute.TYPE_ENUM and not isinstance(attribute_value, EnumValue):
-                    attribute_value = EnumValue.objects.get(value=attribute_value)
+                    if attribute_value is not None: 
+                        attribute_value = EnumValue.objects.get(value=attribute_value)
                 attribute.save_value(self.instance, attribute_value)
 
     def validate_attributes(self):


### PR DESCRIPTION
## Description
I added one line that checks if `attribute_value` is not `None` before passing it as a search parameter to `EnumValue.objects.get()`.

## Motivation and Context
I encountered this problem when I created a multiple choice attribute and marked it as *not* required. Since it is not required, I expected to be able to leave it unselected my model admin page. However, an `EntityValue.DoesNotExist` exception is thrown when I click save.
Fixes #57 

## How Has This Been Tested?
I used my version of the code in a project and I was able to save my model without errors. I also ran the existing tests and they all passed.

## Types of Changes
* What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Thank you!
