### PR TITLE
New feature: many to many to content type on attribute

### DIFF
--- a/eav/migrations/0001_initial.py
+++ b/eav/migrations/0001_initial.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
                 ('modified', models.DateTimeField(auto_now=True, verbose_name='Modified')),
                 ('required', models.BooleanField(default=False, verbose_name='Required')),
                 ('display_order', models.PositiveIntegerField(default=1, verbose_name='Display order')),
-                ('entity_ct', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='attribute_entities', to='contenttypes.ContentType')),
+                ('entity_ct', models.ManyToManyField(to='contenttypes.ContentType', blank=True)),
             ],
             options={
                 'ordering': ['name'],

--- a/eav/migrations/0001_initial.py
+++ b/eav/migrations/0001_initial.py
@@ -27,6 +27,7 @@ class Migration(migrations.Migration):
                 ('modified', models.DateTimeField(auto_now=True, verbose_name='Modified')),
                 ('required', models.BooleanField(default=False, verbose_name='Required')),
                 ('display_order', models.PositiveIntegerField(default=1, verbose_name='Display order')),
+                ('entity_ct', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='attribute_entities', to='contenttypes.ContentType', verbose_name='Belongs to')),
             ],
             options={
                 'ordering': ['name'],

--- a/eav/migrations/0001_initial.py
+++ b/eav/migrations/0001_initial.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
                 ('modified', models.DateTimeField(auto_now=True, verbose_name='Modified')),
                 ('required', models.BooleanField(default=False, verbose_name='Required')),
                 ('display_order', models.PositiveIntegerField(default=1, verbose_name='Display order')),
-                ('entity_ct', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='attribute_entities', to='contenttypes.ContentType', verbose_name='Belongs to')),
+                ('entity_ct', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='attribute_entities', to='contenttypes.ContentType')),
             ],
             options={
                 'ordering': ['name'],

--- a/eav/models.py
+++ b/eav/models.py
@@ -184,18 +184,12 @@ class Attribute(models.Model):
     """
     required = models.BooleanField(verbose_name = _('Required'), default = False)
 
-    entity_ct = models.ForeignKey(
-        ContentType,
-        null         = True,
-        blank        = True,
-        on_delete    = models.PROTECT,
-        related_name = 'attribute_entities'
-    )
+    entity_ct = models.ManyToManyField(ContentType, blank=True)
     """
-    This field allows you to specify a foreign key to a content type.
-    This would be useful, for example, if you wanted an attribute to apply only to one entity.
-    In that case, you could filter by content type in the :meth:`~eav.registry.EavConfig.get_attributes`
-    method of that entity's config.
+    This field allows you to specify a relationship with any number of content types.
+    This would be useful, for example, if you wanted an attribute to apply only to
+    a subset of entities. In that case, you could filter by content type in the
+    :meth:`~eav.registry.EavConfig.get_attributes` method of that entity's config.
     """
 
     enum_group = models.ForeignKey(

--- a/eav/models.py
+++ b/eav/models.py
@@ -184,6 +184,15 @@ class Attribute(models.Model):
     """
     required = models.BooleanField(verbose_name = _('Required'), default = False)
 
+    entity_ct = models.ForeignKey(
+        ContentType,
+        null         = True,
+        blank        = True,
+        on_delete    = models.PROTECT,
+        related_name = 'attribute_entities',
+        verbose_name = _('Belongs to')
+    )
+
     enum_group = models.ForeignKey(
         EnumGroup,
         verbose_name = _('Choice Group'),

--- a/eav/models.py
+++ b/eav/models.py
@@ -189,9 +189,14 @@ class Attribute(models.Model):
         null         = True,
         blank        = True,
         on_delete    = models.PROTECT,
-        related_name = 'attribute_entities',
-        verbose_name = _('Belongs to')
+        related_name = 'attribute_entities'
     )
+    """
+    This field allows you to specify a foreign key to a content type.
+    This would be useful, for example, if you wanted an attribute to apply only to one entity.
+    In that case, you could filter by content type in the :meth:`~eav.registry.EavConfig.get_attributes`
+    method of that entity's config.
+    """
 
     enum_group = models.ForeignKey(
         EnumGroup,


### PR DESCRIPTION
## Description
The problem is described in #40. Currently, there is no way to make an attribute apply to only one model. To fix this, I added a new field `entity_ct` to the `Attribute` class which is a many to many field to the `ContentType` model. This allows a user to specify one or more models to which the attribute applies. For example, a developer could now write
```python
class CarConfig(EavConfig):
    @classmethod
    def get_attributes(cls):
        ct = ContentType.objects.get(model='car')
        return Attribute.objects.filter(Q(entity_ct=ct) | Q(entity_ct=None))

eav.register(Car, CarConfig)
```
The developer could repeat this config for all entities, and now any `Attribute` with `entity_ct` containing `Car` would apply only to the `Car` model.

## Motivation and Context
Fixes #40 

## How Has This Been Tested?
I didn't add any new logic, just a new field, so there isn't really anything new to test. I ran all the existing tests to make sure nothing broke and they all passed.

## Types of Changes
* What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Thank you!
