### PR TITLE
Add instance parameter to config get_attributes

### DIFF
--- a/eav/models.py
+++ b/eav/models.py
@@ -503,7 +503,9 @@ class Entity(object):
         Return a query set of all :class:`Attribute` objects that can be set
         for this entity.
         """
-        return self.instance._eav_config_cls.get_attributes().order_by('display_order')
+        return self.instance._eav_config_cls.get_attributes(
+            instance=self.instance
+        ).order_by('display_order')
 
     def _hasattr(self, attribute_slug):
         """

--- a/eav/registry.py
+++ b/eav/registry.py
@@ -33,7 +33,7 @@ class EavConfig(object):
     generic_relation_related_name = None
 
     @classmethod
-    def get_attributes(cls):
+    def get_attributes(cls, instance=None):
         """
         By default, all :class:`~eav.models.Attribute` object apply to an
         entity, unless you provide a custom EavConfig class overriding this.

--- a/tests/attributes.py
+++ b/tests/attributes.py
@@ -24,7 +24,7 @@ class Attributes(TestCase):
             generic_relation_related_name = 'encounters'
 
             @classmethod
-            def get_attributes(cls):
+            def get_attributes(cls, instance=None):
                 return Attribute.objects.filter(slug__contains='a')
 
         eav.register(Encounter, EncounterEavConfig)
@@ -76,7 +76,7 @@ class Attributes(TestCase):
     def test_illegal_assignemnt(self):
         class EncounterEavConfig(EavConfig):
             @classmethod
-            def get_attributes(cls):
+            def get_attributes(cls, instance=None):
                 return Attribute.objects.filter(datatype=Attribute.TYPE_INT)
 
         eav.unregister(Encounter)


### PR DESCRIPTION
## Description
Currently there is no way to apply attributes on a per-instance level. This PR adds that capability by passing the entity instance to the `get_attributes` method of the config class.

## Motivation and Context
I found a use case where it would be useful to apply attributes on a per-instance basis instead of a per-model basis. For example, I have a heirarchy of product categories, and each product has a foreign key to a node in the heirarchy. I want to apply attributes based on which node the product links to.

## How Has This Been Tested?
I had to fix a couple tests to work with the new api of the `get_attributes` method. After making those changes, all tests passed.

## Types of Changes
* What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Thank you!
