### PR TITLE
Move Attribute.entity_ct to own migration file

### DIFF
--- a/eav/migrations/0001_initial.py
+++ b/eav/migrations/0001_initial.py
@@ -7,6 +7,7 @@ import eav.fields
 
 
 class Migration(migrations.Migration):
+    """Initial migration that creates the Attribute, EnumGroup, EnumValue, and Value models."""
 
     initial = True
 
@@ -27,7 +28,6 @@ class Migration(migrations.Migration):
                 ('modified', models.DateTimeField(auto_now=True, verbose_name='Modified')),
                 ('required', models.BooleanField(default=False, verbose_name='Required')),
                 ('display_order', models.PositiveIntegerField(default=1, verbose_name='Display order')),
-                ('entity_ct', models.ManyToManyField(to='contenttypes.ContentType', blank=True)),
             ],
             options={
                 'ordering': ['name'],

--- a/eav/migrations/0002_add_entity_ct_field.py
+++ b/eav/migrations/0002_add_entity_ct_field.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Add entity_ct field to Attribute model."""
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('eav', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='attribute',
+            name='entity_ct',
+            field=models.ManyToManyField(blank=True, to='contenttypes.ContentType'),
+        ),
+    ]

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)


### PR DESCRIPTION
(Provide a general summary of your changes in the Title above)

## Description
This PR does 4 things:
1. Removes the `entity_ct` field from `0001_initial.py` that was added in #59 
2. Creates a new migration file to create `Attribute.entity_ct`
3. Documents migration classes in 0001 and 0002 migration files
4. Add a `manage.py` file to allow for CLI management

These changes allow for upgrades to properly execute. Addresses issue #62 

## Motivation and Context
Issue #62 

## How Has This Been Tested?
No tests added. Current tests all pass.

## Types of Changes
* What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.