### PR TITLE
fixes https://github.com/jazzband/django-eav2/issues/163

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ tags
 
 ## Mac
 .DS_Store
+
+
+## IDE
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ tags
 
 ## IDE
 .idea
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ We follow [Semantic Versions](https://semver.org/) starting at the `0.14.0` rele
 
 ### Bug Fixes
 
+- Fixes FieldError when filtering on foreign keys [#163](https://github.com/jazzband/django-eav2/issues/163)
+
 ### Misc
 
 ## 1.2.0 (2021-12-18)

--- a/eav/queryset.py
+++ b/eav/queryset.py
@@ -22,7 +22,7 @@ Q-expressions need to be rewritten for two reasons:
 from functools import wraps
 from itertools import count
 
-from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
+from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist, FieldError
 from django.db.models import Case, IntegerField, Q, When
 from django.db.models.query import QuerySet
 from django.db.utils import NotSupportedError
@@ -166,25 +166,28 @@ def eav_filter(func):
         nargs = []
         nkwargs = {}
 
-        for arg in args:
-            if isinstance(arg, Q):
-                # Modify Q objects (warning: recursion ahead).
-                arg = expand_q_filters(arg, self.model)
-                # Rewrite Q-expression to safeform.
-                arg = rewrite_q_expr(self.model, arg)
-            nargs.append(arg)
+        try:
+            for arg in args:
+                if isinstance(arg, Q):
+                    # Modify Q objects (warning: recursion ahead).
+                    arg = expand_q_filters(arg, self.model)
+                    # Rewrite Q-expression to safeform.
+                    arg = rewrite_q_expr(self.model, arg)
+                nargs.append(arg)
 
-        for key, value in kwargs.items():
-            # Modify kwargs (warning: recursion ahead).
-            nkey, nval = expand_eav_filter(self.model, key, value)
+            for key, value in kwargs.items():
+                # Modify kwargs (warning: recursion ahead).
+                nkey, nval = expand_eav_filter(self.model, key, value)
 
-            if nkey in nkwargs:
-                # Apply AND to both querysets.
-                nkwargs[nkey] = (nkwargs[nkey] & nval).distinct()
-            else:
-                nkwargs.update({nkey: nval})
+                if nkey in nkwargs:
+                    # Apply AND to both querysets.
+                    nkwargs[nkey] = (nkwargs[nkey] & nval).distinct()
+                else:
+                    nkwargs.update({nkey: nval})
 
-        return func(self, *nargs, **nkwargs)
+            return func(self, *nargs, **nkwargs)
+        except FieldError:
+            return func(self, *args, **kwargs)
 
     return wrapper
 

--- a/eav/queryset.py
+++ b/eav/queryset.py
@@ -248,18 +248,8 @@ def expand_eav_filter(model_cls, key, value):
 
         return '%s__in' % gr_name, value
 
-    try:
-        field = model_cls._meta.get_field(fields[0])
-    except FieldDoesNotExist:
-        return key, value
-
-    # Leave these types of fields alone
-    if not field.auto_created or field.concrete or field.is_relation:
-        return key, value
-
-    sub_key = '__'.join(fields[1:])
-    key, value = expand_eav_filter(field.model, sub_key, value)
-    return '{0}__{1}'.format(fields[0], key), value
+    # Not an eav field, so keep as is
+    return key, value
 
 
 class EavQuerySet(QuerySet):

--- a/eav/queryset.py
+++ b/eav/queryset.py
@@ -253,12 +253,13 @@ def expand_eav_filter(model_cls, key, value):
     except FieldDoesNotExist:
         return key, value
 
-    if not field.auto_created or field.concrete:
+    # Leave these types of fields alone
+    if not field.auto_created or field.concrete or field.is_relation:
         return key, value
-    else:
-        sub_key = '__'.join(fields[1:])
-        key, value = expand_eav_filter(field.model, sub_key, value)
-        return '{}__{}'.format(fields[0], key), value
+
+    sub_key = '__'.join(fields[1:])
+    key, value = expand_eav_filter(field.model, sub_key, value)
+    return '{0}__{1}'.format(fields[0], key), value
 
 
 class EavQuerySet(QuerySet):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 import eav
 from eav.models import Attribute, EnumGroup, EnumValue, Value
 from eav.registry import EavConfig
-from test_project.models import Encounter, Patient
+from test_project.models import Encounter, Patient, ExampleModel
 
 
 class Queries(TestCase):
@@ -292,3 +292,9 @@ class Queries(TestCase):
         eav.unregister(Patient)
         eav.register(Patient, config_cls=CustomConfig)
         self.assert_order_by_results(eav_attr='data')
+
+    def test_fk_filter(self):
+        e = ExampleModel.objects.create(name='test1')
+        p = Patient.objects.get_or_create(name='Beth', example=e)[0]
+        c = ExampleModel.objects.filter(patient=p)
+        self.assertEqual(c.count(), 1)


### PR DESCRIPTION
# I'm helping!
When attempting a reverse filter using a foreign key on model registered with eav, a django core exception is (django.core.exceptions.FieldError: Related Field got invalid lookup) raised. To address this I've added a try/except in the eav_filter function in queryset.py and return the original args and kwargs.

## Checklist
- [ x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc.)
- [ x] I have created at least one test case for the changes I have made


## Pull Request type
Please check the type of change your PR introduces:
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related issue(s)
- Closes #163 

Example. Refs #
https://github.com/jazzband/django-eav2/issues/163
