### PR TITLE
Ensure eav.register() Maintains Manager Order

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2,8 +2,10 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 
 import eav
+from eav.managers import EntityManager
 from eav.registry import EavConfig
 from test_project.models import (
+    Doctor,
     Encounter,
     ExampleMetaclassModel,
     ExampleModel,
@@ -112,3 +114,22 @@ class RegistryTests(TestCase):
         # Reverse check: managers should be empty again
         eav.unregister(User)
         assert bool(User._meta.local_managers) is False
+
+def test_default_manager_stays() -> None:
+    """
+    Test to ensure default manager remains after registration.
+
+    This test verifies that the default manager of the Doctor model is correctly
+    replaced or maintained after registering a new EntityManager. Specifically,
+    if the model's Meta default_manager_name isn't set, the test ensures that
+    the default manager remains as 'objects' or the first manager declared in
+    the class.
+    """
+    instance_meta = Doctor._meta
+    assert instance_meta.default_manager_name is None
+    assert isinstance(instance_meta.default_manager, EntityManager)
+
+    # Explicity test this as for our test setup, we want to have a state where
+    # the default manager is 'objects'
+    assert instance_meta.default_manager.name == 'objects'
+    assert len(instance_meta.managers) == 2

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -115,6 +115,7 @@ class RegistryTests(TestCase):
         eav.unregister(User)
         assert bool(User._meta.local_managers) is False
 
+
 def test_default_manager_stays() -> None:
     """
     Test to ensure default manager remains after registration.


### PR DESCRIPTION
# I'm helping!

<!--
Thank you for submitting a Pull Request. We appreciate it!

Please, fill in all the required information
to make our review and merging processes easier.
-->

## Checklist

<!--
Please check everything that applies:
-->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc.)
- [x] I have created at least one test case for the changes I have made
- [] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Pull Request type

<!--
Please try to limit your pull request to one type, submit multiple pull requests if needed.
-->

Please check the type of change your PR introduces:

- [x] Bugfix

## Other Information

This addresses an issue where the order of managers in the model's `_meta` was not maintained correctly when adding a new `EntityManager`. The `creation_counter` of the new manager is set to ensure it maintains the correct order relative to existing managers.

I discovered the issue when attempting add a new manager, yet Django wanted to make migrations to the managers and the default manager wasn't available in the a migration `RunPython` call.

