### PR TITLE
Restore backward compatibility for Attribute creation with invalid slugs

### DIFF
--- a/eav/models/attribute.py
+++ b/eav/models/attribute.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Optional
 
 from django.contrib.contenttypes.models import ContentType
@@ -311,13 +312,10 @@ class Attribute(models.Model):
         super().clean_fields(exclude=exclude)
 
         if not self.slug.isidentifier():
-            raise ValidationError(
-                {
-                    "slug": _(
-                        "Slug must be a valid Python identifier (no spaces, "
-                        + "special characters, or leading digits).",
-                    ),
-                },
+            warnings.warn(
+                f"Slug '{self.slug}' is not a valid Python identifier. "
+                + "Consider updating it.",
+                stacklevel=3,
             )
 
     def get_choices(self):

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -167,8 +167,15 @@ class TestAttributeModel(django.TestCase):
 
 
 @pytest.mark.django_db
-def test_attribute_create_with_invalid_slug():
-    with pytest.raises(ValidationError):
+def test_attribute_create_with_invalid_slug() -> None:
+    """
+    Test that creating an Attribute with an invalid slug raises a UserWarning.
+
+    This test ensures that when an Attribute is created with a slug that is not
+    a valid Python identifier, a UserWarning is raised. The warning should
+    indicate that the slug is invalid and suggest updating it.
+    """
+    with pytest.warns(UserWarning):
         Attribute.objects.create(
             name="Test Attribute",
             slug="123-invalid",


### PR DESCRIPTION
This MR addresses a backward compatibility issue introduced by a recent change in the Attribute model's validation process.

Key changes:

- Replace ValidationError with a warning when creating Attributes with invalid slugs
- Update the corresponding test to check for UserWarning instead of ValidationError
- This change allows existing code to continue functioning while still alerting users to potential issues with invalid slugs.