### PR TITLE
Fix for issue #648: Ensure choices are valid (value, label) tuples

### DIFF
--- a/eav/forms.py
+++ b/eav/forms.py
@@ -107,7 +107,7 @@ class BaseDynamicEntityForm(ModelForm):
 
             if datatype == attribute.TYPE_ENUM:
                 values = attribute.get_choices().values_list("id", "value")
-                choices = ["", "-----", *list(values)]
+                choices = [("", ""), ("-----", "-----"), *list(values)]
                 defaults.update({"choices": choices})
 
                 if value:


### PR DESCRIPTION
(cherry picked from commit 30e8873b10db560b845f23697e00d20c42d7a989)

Closes #648 
